### PR TITLE
Better explain the --basic flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ that you can use within a WordPress plugin, for example.
 **OPTIONS**
 
 	[--basic]
-		Start in fail-safe mode, even if Boris is available.
+		Force the use of WP-CLI's built-in PHP REPL, even if the Boris or
+		PsySH PHP REPLs are available.
 
 **EXAMPLES**
 

--- a/src/Shell_Command.php
+++ b/src/Shell_Command.php
@@ -14,7 +14,8 @@ class Shell_Command extends \WP_CLI_Command {
 	 * ## OPTIONS
 	 *
 	 * [--basic]
-	 * : Start in fail-safe mode, even if Boris is available.
+	 * : Force the use of WP-CLI's built-in PHP REPL, even if the Boris or
+	 * PsySH PHP REPLs are available.
 	 *
 	 * ## EXAMPLES
 	 *


### PR DESCRIPTION
## Changes

Replaces the former definition for the `--basic` flag,

> Start in fail-safe mode, even if Boris is available.

with a longer explanation:

> Force the use of WP-CLI's built-in PHP REPL, even if the Boris or PsySH PHP REPLs are available.

This change is made in README.md and in the shell command's docblock, using formatting for multiline explanations copied from the README.md and docblock for `wp db export [<file>]`.

## Why

To better explain what `--basic` does and to answer my question in #22, "What is Boris?". 

Closes #22.