### PR TITLE
Fixed PsySH initialization

### DIFF
--- a/src/Shell_Command.php
+++ b/src/Shell_Command.php
@@ -45,7 +45,8 @@ class Shell_Command extends WP_CLI_Command {
 		}
 
 		if ( 'Psy\\Shell' === $class ) {
-			Psy\Shell::debug();
+			$shell = new Psy\Shell();
+			$shell->run();
 		} else {
 			$repl = new $class( 'wp> ' );
 			$repl->start();


### PR DESCRIPTION
Hello! Thanks for this amazing project!

I found a small bug while trying to integrate with PsySH, seems like the incorrect command is used to initialize PsySH:

![Screenshot from 2020-10-14 23-06-59](https://user-images.githubusercontent.com/1264099/96068349-36992980-0e72-11eb-9962-a3b442d7128a.png)

This happens because `Psy\Shell::debug()` is used to introduce breakpoints.

Note that `Psy\Shell->run()` is also used by all other integrations: https://github.com/bobthecow/psysh/wiki/Integrations

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
