### PR TITLE
Add `composer phpcbf` and allow `wordpress-core-installer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "process-timeout": 7200,
         "sort-packages": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "johnpbloch/wordpress-core-installer": true
         }
     },
     "extra": {
@@ -49,6 +50,7 @@
         "lint": "run-linter-tests",
         "phpcs": "run-phpcs-tests",
         "phpunit": "run-php-unit-tests",
+        "phpcbf": "run-phpcbf-cleanup",
         "prepare-tests": "install-package-tests",
         "test": [
             "@lint",


### PR DESCRIPTION
See https://github.com/wp-cli/.github/issues/41