### PR TITLE
Missing do construct

### DIFF
--- a/src/WP_CLI/Shell/REPL.php
+++ b/src/WP_CLI/Shell/REPL.php
@@ -63,6 +63,7 @@ class REPL {
 				'global',
 				'unset',
 				'function',
+				'do',
 				'while',
 				'for',
 				'foreach',


### PR DESCRIPTION
No benefit to excluding it, and trying to use it throws a parse error because of the prepended `return`.
